### PR TITLE
Closes #27 switch scoring lib

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -142,7 +142,7 @@ The source field is used to identify what produced the title and descriptions fi
 The HC4 data sets use "original" for the original English queries.
 Experiments may also involve various translations that are described in the source field.
 
-To filter out topics that do not have qrels for that language, use the parameter `filter_lang`.
+To filter out topics that do not have qrels for that language, use the parameter `qrels_lang`.
 For example, you may want to use English topics, but only those that have judgments for Russian:
 
 ```yaml
@@ -151,7 +151,7 @@ topics:
     format: json
     lang: eng
     source: original
-    filter_lang: rus
+    qrels_lang: rus
     encoding: utf8
     path: /exp/scale21/path/to/topics
   fields: title

--- a/environment-cpu.yml
+++ b/environment-cpu.yml
@@ -29,4 +29,4 @@ dependencies:
     - luqum
     - parsivar-scale
     - pyserini>=0.13.0
-    - pytrec_eval
+    - pytrec-eval-terrier==0.5.2

--- a/environment.yml
+++ b/environment.yml
@@ -29,4 +29,4 @@ dependencies:
     - luqum
     - parsivar-scale
     - pyserini>=0.13.0
-    - pytrec_eval
+    - pytrec-eval-terrier==0.5.2

--- a/patapsco/schema.py
+++ b/patapsco/schema.py
@@ -85,7 +85,7 @@ class TopicsInputConfig(BaseConfig):
     lang: str
     source: str
     encoding: str = "utf8"
-    filter_lang: Optional[str]  # language code - filter out topics without this language in languages_with_qrels
+    qrels_lang: Optional[str]  # language code - filter out topics without this language in languages_with_qrels
     strip_non_digits: bool = False
     prefix: Union[bool, str] = False  # use "EN-" or similar for CLEF sgml topics
     path: Union[str, list]

--- a/patapsco/topics.py
+++ b/patapsco/topics.py
@@ -145,21 +145,21 @@ class SkipEntry(Exception):
 class Hc4JsonTopicReader(InputIterator):
     """Iterator over topics from jsonl file """
 
-    def __init__(self, path, encoding, lang, source, filter_lang=None, **kwargs):
+    def __init__(self, path, encoding, lang, source, qrels_lang=None, **kwargs):
         """
         Args:
             path (str): Path to topics file.
             encoding (str): File encoding.
             lang (str): Language of the topics.
             source (str): Source of the topic (translation, enhancement, etc.)
-            filter_lang (str): Remove topics that do not have this lang in languages_with_qrels
+            qrels_lang (str): Remove topics that do not have this lang in languages_with_qrels
             **kwargs (dict): Unused
         """
         self.path = path
         self.encoding = encoding
         self.lang = lang
         self.source = source
-        self.filter_lang = filter_lang if filter_lang else self.lang
+        self.qrels_lang = qrels_lang
         self.num_skipped = 0
         self.topics = iter(self._parse(path, encoding))
 
@@ -174,8 +174,8 @@ class Hc4JsonTopicReader(InputIterator):
 
     def _construct(self, data):
         try:
-            #if self.filter_lang not in data['languages_with_qrels']:
-            #    raise SkipEntry()
+            if self.qrels_lang and self.qrels_lang not in data['languages_with_qrels']:
+                raise SkipEntry()
             for topic in data['topics']:
                 if topic['lang'] == self.lang and topic['source'] == self.source:
                     self._validate(data['topic_id'], topic)

--- a/setup.py
+++ b/setup.py
@@ -40,7 +40,7 @@ setuptools.setup(
         "pydantic>=1.7.1,<1.8.0",
         "pymorphy2",
         "pyserini>=0.13.0",
-        "pytrec_eval",
+        "pytrec-eval-terrier==0.5.2",
         "pyyaml",
         "sacremoses",
         "spacy>=3.0.0",

--- a/tests/test_topics.py
+++ b/tests/test_topics.py
@@ -92,11 +92,11 @@ class TestHc4JsonTopicReader:
     def test_parse_json_topics_filter_by_lang(self):
         directory = pathlib.Path(__file__).parent / 'json_files'
         path = directory / 'topics_different_langs.jsonl'
-        topic_iter = Hc4JsonTopicReader(str(path.absolute()), 'utf8', 'zho', 'translation')
+        topic_iter = Hc4JsonTopicReader(str(path.absolute()), 'utf8', 'eng', 'original', 'zho')
         topic = next(topic_iter)
         assert topic.id == '001'
-        assert topic.title == '测试1'
-        assert topic.desc == '第一次测试'
+        assert topic.title == 'Test 1'
+        assert topic.desc == 'First test'
         assert topic.report == 'report 1'
         with pytest.raises(StopIteration):
             next(topic_iter)


### PR DESCRIPTION
pyterrier has repackaged pytrec_eval with a prebuilt trec_eval library rather than requiring setup to download the code and build it. This should solve build issues for containers and Windows.