### PR TITLE
Closes #27 use pytrec-eval-terrier

### DIFF
--- a/environment-cpu.yml
+++ b/environment-cpu.yml
@@ -29,4 +29,4 @@ dependencies:
     - luqum
     - parsivar-scale
     - pyserini>=0.13.0
-    - pytrec_eval
+    - pytrec-eval-terrier==0.5.2

--- a/environment.yml
+++ b/environment.yml
@@ -29,4 +29,4 @@ dependencies:
     - luqum
     - parsivar-scale
     - pyserini>=0.13.0
-    - pytrec_eval
+    - pytrec-eval-terrier==0.5.2

--- a/setup.py
+++ b/setup.py
@@ -40,7 +40,7 @@ setuptools.setup(
         "pydantic>=1.7.1,<1.8.0",
         "pymorphy2",
         "pyserini>=0.13.0",
-        "pytrec_eval",
+        "pytrec-eval-terrier==0.5.2",
         "pyyaml",
         "sacremoses",
         "spacy>=3.0.0",


### PR DESCRIPTION
pyterrier has repackaged pytrec_eval with a prebuilt trec_eval library rather than requiring setup to download the code and build it. This should solve build issues for containers and Windows.